### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "nodejs"
+run = "ng "

--- a/README.md
+++ b/README.md
@@ -12,3 +12,5 @@ This project is a tool for developers to help them in their daily work. As of no
   
      - [ ] Regular expression tester
      - [ ] Extra white space remover
+
+[![Run on Repl.it](https://repl.it/badge/github/vagabondtechie/dev-helper)](https://repl.it/github/vagabondtechie/dev-helper)


### PR DESCRIPTION
This pull request configures this repository to be run on Repl.it.      It adds a `.replit` configuration file and a Repl.it badge to the `README`.
     You can read more about running repos on Repl.it [here](https://docs.repl.it/repls/dot-replit), or view the Repl [here](https://repl.it/@vagabondtechie1/dev-helper).